### PR TITLE
Fix border overlay issue

### DIFF
--- a/GroupBox.Avalonia/GroupBox.axaml
+++ b/GroupBox.Avalonia/GroupBox.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
   <Design.PreviewWith>
-    <GroupBox Header="GroupBox">
+    <GroupBox Header="GroupBox" Margin="5">
       <StackPanel>
         <RadioButton Content="RadioButton1" />
         <RadioButton Content="RadioButton2" />
@@ -38,6 +38,7 @@
                     Grid.RowSpan="3"
                     Grid.Column="0"
                     Grid.ColumnSpan="4"
+                    Margin="0,0,1,1"
                     Background="{TemplateBinding Background}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"


### PR DESCRIPTION
With the Fluent style, the content hides the right and bottom border.  With the Simple style, the content hides the right border.  Adding a margin to PART_Border fixes the issue.  The margin on the preview isn't necessary.  It just makes the issue easier to see.
